### PR TITLE
fix core.makeRequest

### DIFF
--- a/core.js
+++ b/core.js
@@ -75,27 +75,6 @@ function makeRequest (object, callback, responseCB, postData) {
         req.write(postData);
     }
 
-    req.on('close', function () {
-        console.log('RESPONSE CODE: ' + response.statusCode);
-        //console.log('ACCUMULATOR: ', accumulator);
-
-        // first assume accumulator is JSON object
-        var responseContent;
-        try {
-            responseContent = JSON.parse(accumulator);
-        }
-        catch (err) {
-            responseContent = accumulator;
-        }
-
-        callback(responseContent, response.statusCode);
-
-        if (responseCB) {
-            responseCB(response);
-        }
-
-    });
-
     req.end();
 }
 


### PR DESCRIPTION
Was redundant before: `res.on('end',..)` and `req.on('close',...)` both called the callback function

New branch for this merge because this change in `xkcd` didn't get merged in.
